### PR TITLE
fix: invalid tailwind class on container component

### DIFF
--- a/src/common/container/container.tsx
+++ b/src/common/container/container.tsx
@@ -11,7 +11,7 @@ export const Container: React.FC<ContainerProps> = ({
 }) => (
   <div
     className={cn(
-      `2xl:w-[96rem]) mx-auto w-full px-4 sm:w-[40rem] md:w-[48rem] lg:w-[64rem] xl:w-[80rem]`,
+      `mx-auto w-full px-4 sm:w-[40rem] md:w-[48rem] lg:w-[64rem] xl:w-[80rem] 2xl:w-[96rem]`,
       className,
     )}
     {...props}


### PR DESCRIPTION
## Description of the change

I accidentally introduced an invalid class on #83 , this PR fixes it (the issue was a rogue `)` character on the `className` prop).

## Related PRs

- #83
